### PR TITLE
Fix infinite wait for updated build status on failed builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "open-build-service-api"
 version = "0.1.0"
-source = "git+https://github.com/collabora/open-build-service-rs#cce42e9f8b6e82933c96eb9d18c400c1a9caf940"
+source = "git+https://github.com/collabora/open-build-service-rs#057b07290786d010a4190239cbfd0965cff667c4"
 dependencies = [
  "base16ct",
  "bytes",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "open-build-service-mock"
 version = "0.1.0"
-source = "git+https://github.com/collabora/open-build-service-rs#cce42e9f8b6e82933c96eb9d18c400c1a9caf940"
+source = "git+https://github.com/collabora/open-build-service-rs#057b07290786d010a4190239cbfd0965cff667c4"
 dependencies = [
  "base16ct",
  "http-types",

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -467,8 +467,11 @@ impl ObsJobHandler {
                     self.job.trace(String::from_utf8_lossy(&bytes).as_ref());
                 }
 
-                self.job.trace("\n\n(last <=2MB of logs printed above)\n");
-                outputln!("Build failed with reason '{:?}'.", reason);
+                outputln!("{}", "=".repeat(64));
+                outputln!(
+                    "Build failed with reason '{}'.",
+                    reason.to_string().to_lowercase()
+                );
                 outputln!("The last 2MB of the build log is printed above.");
                 outputln!(
                     "(Full logs are available in the build artifact '{}'.)",
@@ -1066,24 +1069,24 @@ mod tests {
             // Testing of reused builds never had the second arch disabled, so
             // also add that build history.
             if test == DputTest::ReusePreviousBuild {
-                context.obs_mock.add_build_history(
+                context.obs_mock.add_job_history(
                     TEST_PROJECT,
                     TEST_REPO,
                     TEST_ARCH_2,
-                    TEST_PACKAGE_1.to_owned(),
-                    MockBuildHistoryEntry {
+                    MockJobHistoryEntry {
+                        package: TEST_PACKAGE_1.to_owned(),
                         rev: dir.rev.clone().unwrap(),
                         srcmd5: dir.srcmd5.clone(),
                         ..Default::default()
                     },
                 );
             }
-            context.obs_mock.add_build_history(
+            context.obs_mock.add_job_history(
                 TEST_PROJECT,
                 TEST_REPO,
                 TEST_ARCH_1,
-                TEST_PACKAGE_1.to_owned(),
-                MockBuildHistoryEntry {
+                MockJobHistoryEntry {
+                    package: TEST_PACKAGE_1.to_owned(),
                     rev: dir.rev.unwrap(),
                     srcmd5: dir.srcmd5,
                     ..Default::default()
@@ -1461,12 +1464,12 @@ mod tests {
                 let repo_2 = repo.clone();
                 tokio::spawn(async move {
                     tokio::time::sleep(OLD_STATUS_SLEEP_DURATION * 10).await;
-                    mock.add_build_history(
+                    mock.add_job_history(
                         &build_info_2.project,
                         &repo_2.repo,
                         &repo_2.arch,
-                        build_info_2.package,
-                        MockBuildHistoryEntry {
+                        MockJobHistoryEntry {
+                            package: build_info_2.package,
                             bcnt: 999,
                             srcmd5: build_info_2.srcmd5.unwrap(),
                             ..Default::default()

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -99,12 +99,12 @@ impl ObsMonitor {
             return Ok(PackageBuildState::Completed(PackageCompletion::Superceded));
         }
 
-        let clinet_package = self
+        let client_package = self
             .client
             .project(self.package.project.clone())
             .package(self.package.package.clone());
 
-        let all_results = retry_request(|| async { clinet_package.result().await }).await?;
+        let all_results = retry_request(|| async { client_package.result().await }).await?;
 
         // TODO: filter this in the API call instead of afterwards
         let result = all_results
@@ -138,7 +138,7 @@ impl ObsMonitor {
             // recorded.
 
             let history = retry_request(|| async {
-                clinet_package
+                client_package
                     .history(&self.package.repository, &self.package.arch)
                     .await
             })


### PR DESCRIPTION
Because the build history only saves successful builds, failed builds would never be added there, leading to the runner to wait forever for it to appear. Instead, rely on the job history, which seems to record successes *and* failures.

This also includes some slight improvements to the appearance of failed builds.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>

<hr>

**In draft state** because it depends on [to-be-merged changes to open-build-service-rs](https://github.com/collabora/open-build-service-rs/pull/7).