### PR TITLE
Use build end times instead of bcnt values to differentiate builds

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -39,7 +39,7 @@ struct JobSpec {
     rules: serde_yaml::Sequence,
 }
 
-fn generate_command(command_name: String, args: &[(&str, &str)]) -> String {
+fn generate_command(command_name: String, args: &[(&str, String)]) -> String {
     let mut command = vec![command_name];
 
     for (arg, value) in args {
@@ -72,19 +72,19 @@ pub fn generate_monitor_pipeline(
         let mut artifact_paths = vec![];
 
         let common_args = vec![
-            ("project", project),
-            ("package", package),
-            ("repository", repo),
-            ("arch", arch),
+            ("project", project.to_owned()),
+            ("package", package.to_owned()),
+            ("repository", repo.to_owned()),
+            ("arch", arch.to_owned()),
         ];
 
         let mut monitor_args = vec![
-            ("rev", rev),
-            ("srcmd5", srcmd5),
-            ("build-log-out", &options.build_log_out),
+            ("rev", rev.to_owned()),
+            ("srcmd5", srcmd5.to_owned()),
+            ("build-log-out", options.build_log_out.clone()),
         ];
-        if let Some(bcnt) = &info.prev_bcnt_for_commit {
-            monitor_args.push(("prev-bcnt-for-commit", bcnt.as_str()));
+        if let Some(endtime) = &info.prev_endtime_for_commit {
+            monitor_args.push(("prev-endtime-for-commit", endtime.to_string()));
         }
         monitor_args.extend_from_slice(&common_args);
         script.push(generate_command("monitor".to_owned(), &monitor_args));
@@ -93,8 +93,7 @@ pub fn generate_monitor_pipeline(
         if let PipelineDownloadBinaries::OnSuccess { build_results_dir } =
             &options.download_binaries
         {
-            let mut download_args: Vec<(_, &str)> =
-                vec![("build-results-dir", build_results_dir.as_str())];
+            let mut download_args = vec![("build-results-dir", build_results_dir.clone())];
             download_args.extend_from_slice(&common_args);
             script.push(generate_command(
                 "download-binaries".to_owned(),


### PR DESCRIPTION
As it turns out, 4cd36f761d167785c925d62f0ed87fa9f856c21a did not entirely fix our bcnt woes; in fact, it made them *worse* in some cases. Although bcnt values for failed builds are recorded in the job history, their values never increase until a successful one. As a result, if a package fails to build and then later succeeds, both of those builds will have an identical bcnt, and the runner will never pick up the successful one.

Looking through the _jobhistory endpoint results showed a different, more promising target to track: build times. They're always guaranteed to change across different builds of the same package, since...they're different builds, running at different times. The endtime in particular was chosen since, if any conflict is at all possible, it's probably more likely to happen with the ready/start times. (It *shouldn't* be, but OBS sometimes does interesting things.)

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>