### PR TITLE
Log to GitLab when the job handler cannot be created

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ async fn main() {
             |job| async {
                 ObsJobHandler::from_obs_config_in_job(job, HandlerOptions::default()).map_err(
                     |err| {
-                        error!("Failed to create new client: {:?}", err);
+                        error!(gitlab.output = true, "Failed to handle new job: {:?}", err);
                     },
                 )
             },


### PR DESCRIPTION
This can happen due to e.g. configuration issues on the repo, so it makes sense to log it somewhere other than just the service logs.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>