### PR TITLE
Fix including excluded repositories due to broken status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "open-build-service-api"
 version = "0.1.0"
-source = "git+https://github.com/collabora/open-build-service-rs#e89ee96cad6691cf5e8ea99cb1ea60f293184bdd"
+source = "git+https://github.com/collabora/open-build-service-rs#1bb9a29e289aea1c8e5c6609a4f24cf5f43651ab"
 dependencies = [
  "base16ct",
  "bytes",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "open-build-service-mock"
 version = "0.1.0"
-source = "git+https://github.com/collabora/open-build-service-rs#e89ee96cad6691cf5e8ea99cb1ea60f293184bdd"
+source = "git+https://github.com/collabora/open-build-service-rs#1bb9a29e289aea1c8e5c6609a4f24cf5f43651ab"
 dependencies = [
  "base16ct",
  "http-types",

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error, instrument};
 use crate::{
     artifacts::{save_to_tempfile, ArtifactDirectory},
     binaries::download_binaries,
-    build_meta::{BuildHistoryRetrieval, BuildMeta, CommitBuildInfo, RepoArch},
+    build_meta::{BuildHistoryRetrieval, BuildMeta, BuildMetaOptions, CommitBuildInfo, RepoArch},
     monitor::{MonitoredPackage, ObsMonitor, PackageCompletion, PackageMonitoringOptions},
     pipeline::{generate_monitor_pipeline, GeneratePipelineOptions, PipelineDownloadBinaries},
     prune::prune_branch,
@@ -310,7 +310,10 @@ impl ObsJobHandler {
             &self.client,
             &build_info.project,
             &build_info.package,
-            BuildHistoryRetrieval::Full,
+            &BuildMetaOptions {
+                history_retrieval: BuildHistoryRetrieval::Full,
+                wait_options: Default::default(),
+            },
         )
         .await?;
         debug!(?initial_build_meta);
@@ -328,7 +331,10 @@ impl ObsJobHandler {
                 &self.client,
                 &build_info.project,
                 &build_info.package,
-                BuildHistoryRetrieval::None,
+                &BuildMetaOptions {
+                    history_retrieval: BuildHistoryRetrieval::None,
+                    wait_options: Default::default(),
+                },
             )
             .await?
         };


### PR DESCRIPTION
There's a short period of time after a package is uploaded that OBS might report it as `broken`, with the details set to `empty`. This means that, when the build metadata is gathered, excluded architectures end up being *included*, because the status is `broken` instead of `excluded`.

In order to work around this, wait for a short period of time if the package's status is `broken` and details are `empty`, that way we can actually check if the architecture is excluded.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>

<hr>

In draft status because it depends on https://github.com/collabora/open-build-service-rs/pull/10.