### PR TITLE
Run the service with the least privilege

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,13 @@ RUN apt-get update \
 FROM debian:bullseye-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN adduser --uid 1001 --group --no-create-home --home /app obs-gitlab-runner
+
 RUN apt-get update \
   && apt-get install -y libssl1.1 ca-certificates \
   && rm -rf /var/lib/apt/lists/
 COPY --from=build /app/target/release/obs-gitlab-runner /usr/local/bin/
+
+USER obs-gitlab-runner
 
 ENTRYPOINT /usr/local/bin/obs-gitlab-runner

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -27,13 +27,16 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  fsGroup: 1001
+  runAsUser: 1001
+  runAsGroup: 1001
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION

Make the container run as user 1001 instead of user root. 
Configure SecurityContext to deploy the service in k8s using a non-root user. 
Allow running the service with the least privilege.