### PR TITLE
Allow setting the default monitor job timeout via variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.64.0-slim-bullseye AS build
+FROM rust:1.75.0-slim-bookworm AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 ADD . /app
@@ -7,13 +7,17 @@ RUN apt-get update \
   && apt-get install -y pkg-config libssl-dev \
   && cargo build --release
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN adduser --uid 1001 --group --no-create-home --home /app obs-gitlab-runner
+RUN groupadd --gid 1001 obs-gitlab-runner \
+  && useradd \
+    --uid 1001 --gid 1001 \
+    --no-create-home --home-dir /app \
+    obs-gitlab-runner
 
 RUN apt-get update \
-  && apt-get install -y libssl1.1 ca-certificates \
+  && apt-get install -y libssl3 ca-certificates \
   && rm -rf /var/lib/apt/lists/
 COPY --from=build /app/target/release/obs-gitlab-runner /usr/local/bin/
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
               value: {{ .Values.log_level | quote }}
             - name: OBS_RUNNER_LOG_FORMAT
               value: {{ .Values.log_format | quote }}
+            {{- if .Values.default_monitor_job_timeout }}
+            - name: OBS_RUNNER_DEFAULT_MONITOR_JOB_TIMEOUT
+              value: {{ .Values.default_monitor_job_timeout | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,8 +24,8 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 1001
 
 securityContext:
   capabilities:
@@ -34,7 +34,6 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   allowPrivilegeEscalation: false
-  fsGroup: 1001
   runAsUser: 1001
   runAsGroup: 1001
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 log_level: info
 log_format: json
+default_monitor_job_timeout: ''
 gitlab:
   url: https://your.gitlab.server.org
   #Set the runner token for a first deployment. It's inherited on later


### PR DESCRIPTION
PR #17 added support for job timeouts to the runner. This means that, if your build jobs take a long time to complete, you must now override the timeout via `--job-timeout`.

However, because the given option did not exist in previous releases, deploying the updated version becomes more difficult: the new option is not supported by the old version, but the moment you deploy the new version, your builds might time out until the option is passed. To circumvent this, this PR allows pipelines / jobs to set a default timeout in a variable. If the variable is passed to the old runner version, then it will simply ignore it, circumvent the deployment difficulties.