### PR TITLE
Always include annotations in the Deployment object

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -13,9 +13,9 @@ spec:
       {{- include "obs-gitlab-runner.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/gitlab-token-secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Checksum in annotations ensures that the pod restarts when an object is updated. Previously, checksums were not included when there were no other annotations on the object, so they had no effect.
Instead, always include annotations with at least the checksums, so they can be used regardless.

Fixes: 45bed51a ("Ensure the pod restarts when the K8s secret with the config is updated")