### PR TITLE
Add a temp volume in Helm Chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           env:
             - name: GITLAB_URL
               value: {{ .Values.gitlab.url | quote }}
@@ -47,6 +50,9 @@ spec:
               value: {{ .Values.log_format | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The runner requires a writable folder for temporary storage, as the root filesystem
has been made read-only and it is now failing to do so. Add a /tmp mount to resolve
that while keeping the root filesystem read-only.

Adding the /tmp folder to the Helm chart allows the POD to create a temporary
filesystem for applications that require a writable and volatile storage space to
store temporary files during runtime. Without this temporary folder, such
applications may encounter issues related to file system access or data storage.