### PR TITLE
Release 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obs-gitlab-runner"
-version = "0.1.6"
+version = "0.1.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,7 +17,7 @@ image:
   repository: ghcr.io/collabora/obs-gitlab-runner
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "main"
+  tag: "0.1.8"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Highlights:

* Support job cancellation and let administrators globally set the default monitor job timeout to avoid regressions when relying on the job timeout not being respected, by using:
  * the `--job-timeout` command line parameter
  * the `OBS_RUNNER_DEFAULT_MONITOR_JOB_TIMEOUT` env var
  * the `default_monitor_job_timeout` Helm value
* docker: move to Debian Bookworm
* helm: use the the release image instead of `main`
* helm: run with lower privileges, make the rootfs read-only
* helm: automatically rollout the deployment when the secret changes
* ci: move to actively maintained Rust actions
* ci: bump version for a few actions

Skip 0.1.7 because it was tagged on git but not really released.