### PR TITLE
dependabot: Add config to ignore most versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,32 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    # Not yet supported. See <https://github.com/dependabot/dependabot-core/issues/4009>
+    # versioning-strategy: "increase-if-necessary"
+    ignore:
+      - dependency-name: "tokio"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "serde"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"


### PR DESCRIPTION
To reduce dependabot PR noise.

* Ignore patch for dependencies
* Ignore minor and below for serde
* Ignore minor and below for tokio

Taken from [lava-gitlab-runner](https://github.com/collabora/lava-gitlab-runner/blob/main/.github/dependabot.yaml).