### PR TITLE
ci: Bump rust toolchain to 1.83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
+        with:
+          toolchain: "1.83"
       - run: cargo check --all-targets --all-features
 
   fmt:
@@ -24,8 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
+          toolchain: "1.83"
           components: rustfmt
       - run: cargo fmt --all --check
 
@@ -34,7 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
+        with:
+          toolchain: "1.83"
       - run: cargo test --all-targets --all-features
 
   clippy:
@@ -42,8 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
+          toolchain: "1.83"
           components: clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/src/dsc.rs
+++ b/src/dsc.rs
@@ -18,7 +18,7 @@ impl<'de> Deserialize<'de> for FileEntry {
     {
         struct FileEntryVisitor;
 
-        impl<'de> Visitor<'de> for FileEntryVisitor {
+        impl Visitor<'_> for FileEntryVisitor {
             type Value = FileEntry;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/dsc.rs
+++ b/src/dsc.rs
@@ -7,6 +7,7 @@ use std::marker::PhantomData;
 #[derive(Debug)]
 pub struct FileEntry {
     pub hash: String,
+    #[allow(dead_code)]
     pub size: usize,
     pub filename: String,
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -12,10 +12,10 @@ const INITIAL_INTERVAL: Duration = Duration::from_millis(300);
 fn is_client_error(err: &(dyn std::error::Error + 'static)) -> bool {
     err.downcast_ref::<reqwest::Error>()
         .and_then(|e| e.status())
-        .map_or(false, |status| status.is_client_error())
+        .is_some_and(|status| status.is_client_error())
         || err
             .downcast_ref::<obs::Error>()
-            .map_or(false, |err| matches!(err, obs::Error::ApiError(_)))
+            .is_some_and(|err| matches!(err, obs::Error::ApiError(_)))
 }
 
 fn is_caused_by_client_error(report: &Report) -> bool {
@@ -26,8 +26,7 @@ fn is_caused_by_client_error(report: &Report) -> bool {
             // source()), so we need to examine that error directly.
             || err
                 .downcast_ref::<std::io::Error>()
-                .and_then(|err| err.get_ref())
-                .map_or(false, |err| is_client_error(err))
+                .and_then(|err| err.get_ref()).is_some_and(|err| is_client_error(err))
     })
 }
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -72,7 +72,7 @@ pub struct ObsDscUploader {
 }
 
 impl ObsDscUploader {
-    pub async fn prepare<'a>(
+    pub async fn prepare(
         client: obs::Client,
         mut project: String,
         branch_to: Option<String>,


### PR DESCRIPTION
Matching Debian testing

Update rust toolchain action to avoid dependabot updates

This MR also contains clippys suggestions:
* Unused lifetime specifiers
* Redundant lifetime specifiers
* [unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or) replaced with `is_some_and`
* Tagged size field of `FileEntry` as unused

Clippy is also printing:
warning: the following packages contain code that will be rejected by a future version of Rust: buf_redux v0.8.4, multipart v0.18.0, nom v5.1.2, quick-xml v0.22.0, traitobject v0.1.0, typemap v0.3.3

quick-xml is a dependency of https://github.com/collabora/open-build-service-rs which I notice doesn't have dependabot enabled.