### PR TITLE
dsc: Discard PGP from dsc files

### DIFF
--- a/src/dsc.rs
+++ b/src/dsc.rs
@@ -98,11 +98,50 @@ pub struct Dsc {
     pub files: Vec<FileEntry>,
 }
 
+pub fn discard_pgp(dsc: &[u8]) -> &[u8] {
+    const PGP_HEADER_START: &str = "-----BEGIN PGP SIGNED MESSAGE-----\n";
+    const PGP_HEADER_END: &str = "\n\n";
+    const PGP_FOOTER_START: &str = "-----BEGIN PGP SIGNATURE-----\n";
+
+    if let Ok(dsc_str) = std::str::from_utf8(dsc) {
+        if dsc_str.starts_with(PGP_HEADER_START) {
+            if let Some((_gpg_header, payload_and_sig)) = dsc_str.split_once(PGP_HEADER_END) {
+                if let Some((payload, _sig)) = payload_and_sig.split_once(PGP_FOOTER_START) {
+                    return payload.as_bytes();
+                }
+            }
+        }
+    }
+
+    dsc
+}
+
 #[cfg(test)]
 mod tests {
     use claim::*;
 
     use super::*;
+
+    const TEST_GPG_DSC: &str = "-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+Source: abc
+SomeUnknownAttribute: 10
+Files:
+ hash1 10 file1
+ hash2 27 file2
+-----BEGIN PGP SIGNATURE-----
+
+iQEzBAEBCgAdFiEEQxKqmcM1tb5xMnn0axtijDBFQh4FAmebtGQACgkQaxtijDBF
+Qh6iAwf+NfOEM4+DbA8PPZnVz12bBqBNgMdaOx8CisQtd9xTmOMECaF3u2Vpfcha
+zWRVtVh7Js2UidlHEwdzVJuNwrkneBoIHJEyOd/X2EXI8hOlU71OJGCyx1fayDNp
+zf9Fe9kmlF9PJZRpB33YcTDSf5fYMNG2b4osa0ICOKssXoIbNVjaEPDdx3h/gsVm
+x/JPxsxWjuM98ALa3ncn4UUPrn4QQfbu73qFEKyOLqhjCZxb52LG5/w96bXQodPS
+Zhy+ZtJTpPJA9kuz9vZimQMPVimxUhYQQlBTl+3Bcg2Afw1X57H4MpkS+UPi16id
++DdRlEyxB4frFnYXK84u3VYR3Ml+8A==
+=wcHv
+-----END PGP SIGNATURE-----
+";
 
     const TEST_DSC: &str = "Source: abc
 SomeUnknownAttribute: 10
@@ -110,10 +149,7 @@ Files:
  hash1 10 file1
  hash2 27 file2";
 
-    #[test]
-    fn test_de() {
-        let dsc: Dsc = assert_ok!(rfc822_like::from_str(TEST_DSC));
-
+    fn assert_values(dsc: &Dsc) {
         assert_eq!(dsc.source, "abc");
         assert_eq!(dsc.files.len(), 2);
 
@@ -124,5 +160,19 @@ Files:
         assert_eq!(dsc.files[1].hash, "hash2");
         assert_eq!(dsc.files[1].size, 27);
         assert_eq!(dsc.files[1].filename, "file2");
+    }
+
+    #[test]
+    fn test_de() {
+        let dsc: Dsc = assert_ok!(rfc822_like::from_str(TEST_DSC));
+        assert_values(&dsc);
+    }
+
+    #[test]
+    fn test_gpg_de() {
+        let dsc: Dsc = assert_ok!(rfc822_like::from_bytes(discard_pgp(
+            TEST_GPG_DSC.as_bytes()
+        )));
+        assert_values(&dsc);
     }
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -10,7 +10,11 @@ use md5::{Digest, Md5};
 use open_build_service_api as obs;
 use tracing::{debug, info_span, instrument, trace, Instrument};
 
-use crate::{artifacts::ArtifactDirectory, dsc::Dsc, retry::retry_request};
+use crate::{
+    artifacts::ArtifactDirectory,
+    dsc::{discard_pgp, Dsc},
+    retry::retry_request,
+};
 
 type Md5String = String;
 
@@ -83,8 +87,8 @@ impl ObsDscUploader {
             .get_data(dsc_path.as_str())
             .await
             .wrap_err("Failed to download dsc")?;
-        let dsc: Dsc =
-            rfc822_like::from_bytes(&dsc_contents[..]).wrap_err("Failed to parse dsc")?;
+        let dsc: Dsc = rfc822_like::from_bytes(discard_pgp(&dsc_contents[..]))
+            .wrap_err("Failed to parse dsc")?;
 
         let package = dsc.source.to_owned();
 
@@ -191,7 +195,7 @@ impl ObsDscUploader {
                 .await?;
 
                 let _span = info_span!("find_files_to_remove:parse", %file);
-                let dsc: Dsc = rfc822_like::from_bytes(&contents[..])?;
+                let dsc: Dsc = rfc822_like::from_bytes(discard_pgp(&contents[..]))?;
 
                 to_remove.extend(dsc.files.into_iter().map(|f| f.filename));
             } else if file.ends_with(".changes") {


### PR DESCRIPTION
It's common for dsc files to be signed with PGP clearsign. This results in `rfc822-like` throwing with the error `Line 1 doesn't contain a colon`.

This MR adds the function `discard_pgp` which uses `split_once` twice to extract the payload from a clearsigned dsc file, returning the original buffer if it doesn't match the format.