### PR TITLE
Update branched package meta to match the original

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -121,7 +121,15 @@ impl ObsDscUploader {
                 }
             }
 
+            let original_meta = client_package.meta().await?;
+
             project = branch_to;
+
+            // Update branched package build meta to match the original
+            let client_package = client.project(project.clone()).package(package.clone());
+            let mut target_meta = client_package.meta().await?;
+            target_meta.build = original_meta.build.clone();
+            client_package.set_meta(&target_meta).await?;
         }
 
         Ok(ObsDscUploader {


### PR DESCRIPTION
Currently when branching a package OBS doesn't transfer the originals build meta object to the branched version.

It may be better to fix this upstream.

Fixes https://gitlab.apertis.org/infrastructure/apertis-issues/-/issues/413