### PR TITLE
Run cargo-dependabot-if-necessary to quiet depbot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,32 +1,64 @@
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
----
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-    # Not yet supported. See <https://github.com/dependabot/dependabot-core/issues/4009>
-    # versioning-strategy: "increase-if-necessary"
-    ignore:
-      - dependency-name: "tokio"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-      - dependency-name: "serde"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  labels:
+  - dependencies
+- package-ecosystem: cargo
+  # Not yet supported. See <https://github.com/dependabot/dependabot-core/issues/4009>
+  # versioning-strategy: "increase-if-necessary"
+  directory: /
+  schedule:
+    interval: daily
+  ignore:
+  - dependency-name: bytes
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: camino
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: clap
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: derivative
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: gitlab-runner
+    update-types: []
+  - dependency-name: gitlab-runner-mock
+    update-types: []
+  - dependency-name: serde
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: shell-words
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: shellexpand
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: tempfile
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: tokio
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: url
+    update-types:
+    - version-update:semver-minor
+    - version-update:semver-patch
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-patch
+  labels:
+  - dependencies


### PR DESCRIPTION
Updated `dependabot.yaml` using [cargo-dependabot-if-necessary](https://github.com/sjoerdsimons/cargo-dependabot-if-necessary) to reduce unnecessary update noise.