### PR TITLE
monitor: Filter results based on arch and repository

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -108,11 +108,12 @@ impl ObsMonitor {
         let result = all_results
             .results
             .into_iter()
-            .find(|r| r.arch == self.package.arch)
+            .find(|r| r.repository == self.package.repository && r.arch == self.package.arch)
             .ok_or_else(|| {
                 eyre!(
-                    "Failed to find results for architecture {}",
-                    self.package.arch
+                    "Failed to find results for repository {} and architecture {}",
+                    self.package.repository,
+                    self.package.arch,
                 )
             })?;
 


### PR DESCRIPTION
This was causing builds with multiple repositories to alias the final status, every result for a given arch reporting the same fail/pass status.

https://gitlab.apertis.org/infrastructure/apertis-issues/-/issues/597