### PR TITLE
Refactor retry code on top of tokio-retry2 and macros 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,20 +313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.16",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,7 +2034,6 @@ name = "obs-gitlab-runner"
 version = "0.1.8"
 dependencies = [
  "async-trait",
- "backoff",
  "base16ct 0.2.0",
  "bytes",
  "camino",
@@ -2073,6 +2058,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-retry2",
  "tokio-util 0.7.15",
  "tracing",
  "tracing-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 async-trait = "0.1"
-backoff = { version = "0.4", features = ["tokio"] }
 base16ct = { version = "0.2", features = ["std"] }
 bytes = "1.10"
 camino = "1.1"
@@ -26,6 +25,7 @@ shell-words = "1.1"
 strum = { version = "0.27", features = ["derive"] }
 tempfile = "3.20"
 tokio = { version = "1.45", features = ["full"] }
+tokio-retry2 = { version = "0.5.7", features = ["jitter"] }
 tokio-util = { version = "0.7", features = ["full"] }
 tracing = "0.1"
 tracing-error = "0.2"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -35,7 +35,7 @@ use crate::{
     monitor::{MonitoredPackage, ObsMonitor, PackageCompletion, PackageMonitoringOptions},
     pipeline::{GeneratePipelineOptions, PipelineDownloadBinaries, generate_monitor_pipeline},
     prune::prune_branch,
-    retry::retry_request,
+    retry_request,
     upload::ObsDscUploader,
 };
 
@@ -359,15 +359,14 @@ impl ObsJobHandler {
             outputln!("Package unchanged at revision {}.", result.rev);
 
             if args.rebuild_if_unchanged {
-                retry_request(|| async {
+                retry_request!(
                     self.client
                         .project(build_info.project.clone())
                         .package(build_info.package.clone())
                         .rebuild()
                         .await
-                })
-                .await
-                .wrap_err("Failed to trigger rebuild")?;
+                        .wrap_err("Failed to trigger rebuild")
+                )?;
             } else {
                 // Clear out the history used to track endtime values. This is
                 // normally important to make sure the monitor doesn't

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,67 +1,84 @@
 use std::time::Duration;
 
-use backoff::ExponentialBackoff;
-use futures_util::Future;
-
 use color_eyre::{Report, eyre::Result};
 use open_build_service_api as obs;
-use tracing::instrument;
+use tokio_retry2::strategy::{FibonacciBackoff, jitter};
 
-const INITIAL_INTERVAL: Duration = Duration::from_millis(300);
+fn is_retriable_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    if let Some(err) = err.downcast_ref::<reqwest::Error>() {
+        return err.status().is_none_or(|status| !status.is_client_error());
+    }
 
-fn is_client_error(err: &(dyn std::error::Error + 'static)) -> bool {
-    err.downcast_ref::<reqwest::Error>()
-        .and_then(|e| e.status())
-        .is_some_and(|status| status.is_client_error())
-        || err
-            .downcast_ref::<obs::Error>()
-            .is_some_and(|err| matches!(err, obs::Error::ApiError(_)))
+    if let Some(err) = err.downcast_ref::<obs::Error>() {
+        return !matches!(*err, obs::Error::ApiError(_));
+    }
+
+    false
 }
 
-fn is_caused_by_client_error(report: &Report) -> bool {
+fn is_caused_by_retriable_error(report: &Report) -> bool {
     report.chain().any(|err| {
-        is_client_error(err)
+        is_retriable_error(err)
             // Custom IO errors do not return the custom error itself when its
             // .source() is called (instead returning the custom error's
             // source()), so we need to examine that error directly.
             || err
                 .downcast_ref::<std::io::Error>()
-                .and_then(|err| err.get_ref()).is_some_and(|err| is_client_error(err))
+                .and_then(|err| err.get_ref()).is_some_and(|err| is_retriable_error(err))
     })
 }
 
-#[instrument(skip(func))]
-pub async fn retry_request<T, E, Fut, Func>(func: Func) -> Result<T>
-where
-    Fut: Future<Output = Result<T, E>>,
-    Func: Fn() -> Fut,
-    E: Into<Report>,
-{
-    backoff::future::retry(
-        ExponentialBackoff {
-            max_elapsed_time: None,
-            initial_interval: INITIAL_INTERVAL,
-            ..Default::default()
-        },
-        || async {
-            func().await.map_err(|err| {
-                let report = err.into();
-                if is_caused_by_client_error(&report) {
-                    backoff::Error::permanent(report)
-                } else {
-                    backoff::Error::transient(report)
+pub struct Retrier {
+    backoff: std::iter::Map<FibonacciBackoff, fn(Duration) -> Duration>,
+}
+
+impl Default for Retrier {
+    fn default() -> Self {
+        Self {
+            backoff: FibonacciBackoff::from_millis(900).map(jitter),
+        }
+    }
+}
+
+impl Retrier {
+    pub async fn handle_request_error(&mut self, report: Report) -> Result<()> {
+        if !is_caused_by_retriable_error(&report) {
+            return Err(report);
+        }
+
+        let Some(delay) = self.backoff.next() else {
+            return Err(report);
+        };
+
+        tokio::time::sleep(delay).await;
+        Ok(())
+    }
+}
+
+#[macro_export]
+macro_rules! retry_request {
+    ($expr:expr) => {
+        'outer: {
+            let mut retrier = $crate::retry::Retrier::default();
+            loop {
+                let ret: Result<_, _> = async { $expr }.await;
+                match ret {
+                    Ok(ret) => break 'outer Ok(ret),
+                    Err(err) => {
+                        if let Err(report) = retrier.handle_request_error(err.into()).await {
+                            break 'outer Err(report);
+                        }
+                    }
                 }
-            })
-        },
-    )
-    .await
+            }
+        }
+    };
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicI32, Ordering};
-
     use claims::*;
+    use futures_util::Future;
     use open_build_service_api as obs;
     use rstest::*;
     use wiremock::{
@@ -105,18 +122,19 @@ mod tests {
             TEST_PASS.to_owned(),
         );
 
-        let attempts = AtomicI32::new(0);
+        let mut attempts = 0;
+
         assert_err!(
-            tokio::time::timeout(
-                Duration::from_millis(2000),
-                retry_request(|| {
-                    attempts.fetch_add(1, Ordering::SeqCst);
-                    async { client.project("500".to_owned()).meta().await }
+            tokio::time::timeout(Duration::from_millis(2000), async {
+                retry_request!({
+                    attempts += 1;
+                    client.project("500".to_owned()).meta().await
                 })
-            )
+            })
             .await
         );
-        assert_gt!(attempts.load(Ordering::SeqCst), 1);
+
+        assert_gt!(attempts, 1);
     }
 
     #[rstest]
@@ -129,24 +147,21 @@ mod tests {
             TEST_PASS.to_owned(),
         );
 
-        let attempts = AtomicI32::new(0);
+        let mut attempts = 0;
         assert_err!(
-            tokio::time::timeout(
-                Duration::from_millis(2000),
-                retry_request(|| {
-                    attempts.fetch_add(1, Ordering::SeqCst);
-                    async {
-                        client
-                            .project("500".to_owned())
-                            .meta()
-                            .await
-                            .map_err(std::io::Error::other)
-                    }
+            tokio::time::timeout(Duration::from_millis(2000), async {
+                retry_request!({
+                    attempts += 1;
+                    client
+                        .project("500".to_owned())
+                        .meta()
+                        .await
+                        .map_err(std::io::Error::other)
                 })
-            )
+            })
             .await
         );
-        assert_gt!(attempts.load(Ordering::SeqCst), 1);
+        assert_gt!(attempts, 1);
     }
 
     #[rstest]
@@ -159,15 +174,12 @@ mod tests {
             TEST_PASS.to_owned(),
         );
 
-        let attempts = AtomicI32::new(0);
-        assert_err!(
-            retry_request(|| {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                async { client.project("403".to_owned()).meta().await }
-            })
-            .await
-        );
-        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        let mut attempts = 0;
+        assert_err!(retry_request!({
+            attempts += 1;
+            client.project("403".to_owned()).meta().await
+        }));
+        assert_eq!(attempts, 1);
     }
 
     #[rstest]
@@ -180,20 +192,15 @@ mod tests {
             TEST_PASS.to_owned(),
         );
 
-        let attempts = AtomicI32::new(0);
-        assert_err!(
-            retry_request(|| {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                async {
-                    client
-                        .project("403".to_owned())
-                        .meta()
-                        .await
-                        .map_err(std::io::Error::other)
-                }
-            })
-            .await
-        );
-        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        let mut attempts = 0;
+        assert_err!(retry_request!({
+            attempts += 1;
+            client
+                .project("403".to_owned())
+                .meta()
+                .await
+                .map_err(std::io::Error::other)
+        }));
+        assert_eq!(attempts, 1);
     }
 }


### PR DESCRIPTION
The `backoff` crate has been unmaintained for a while now, so this switches to `tokio-retry2` as gitlab-runner-rs now uses:

https://github.com/collabora/gitlab-runner-rs/pull/90

Additionally, mixing async code with non-FnOnce (*especially* FnMut) closures can be rather perilous, resulting a maze of extra locks and clones. This is bad as-is in the runner, but `tokio-retry2` itself uses an FnMut closure in its API, which makes everything worse. Instead, just switch to a lightweight macro, which also makes it cleaner to pass in a block.