### PR TITLE
actions: Improve clippy handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,11 @@ jobs:
         with:
           toolchain: "1.88"
           components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - uses: clechasseur/rs-clippy-check@v4.0.5
+        with:
+          # setup-rust-toolchain already sets `-D warnings`, but we leave this
+          # here to make the behavior explicit.
+          args: --all-targets --all-features -- -D warnings
 
   clippy-latest:
     name: cargo clippy latest
@@ -63,7 +67,11 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+          # Defaults to '-D warnings', so clear it out manually.
+          rustflags: ''
+      - uses: clechasseur/rs-clippy-check@v4.0.5
+        with:
+          args: --all-targets --all-features
 
   minimal-dependencies:
     name: minimal direct dependencies


### PR DESCRIPTION
Use `clechasseur/rs-clippy-check` to get nicer lint formatting and be able to surface lint errors on `cargo clippy latest` w/o showing failed jobs on CI.

Based on: https://github.com/collabora/open-build-service-rs/pull/40