### PR TITLE
Use JSON arguments for the Dockerfile ENTRYPOINT

### DIFF
--- a/Dockerfile.obs-gitlab-runner
+++ b/Dockerfile.obs-gitlab-runner
@@ -23,4 +23,4 @@ COPY --from=build /app/target/release/obs-gitlab-runner /usr/local/bin/
 
 USER obs-gitlab-runner
 
-ENTRYPOINT /usr/local/bin/obs-gitlab-runner
+ENTRYPOINT ["/usr/local/bin/obs-gitlab-runner"]


### PR DESCRIPTION
In addition to the strange influence on signal handling:

https://docs.docker.com/reference/build-checks/json-args-recommended/

using the shell form as we do also means that CLI arguments won't actually get forwarded to the runner, which isn't particularly useful.