### PR TITLE
Add a new flag `dput --message` to set the commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ pipeline, then use that variable in a flag value as `--flag=$SOME_VARIABLE`.
 dput PROJECT DSC_FILE
   [--branch-to BRANCHED_PROJECT]
   [--build-info-out BUILD_INFO_FILE=build-info.json]
+  [--message MESSAGE]
   [--rebuild-if-unchanged]
 ```
 
@@ -76,6 +77,11 @@ projects.
 ##### `--build-info-out BUILD_INFO_FILE=build-info.json`
 
 Changes the filename that the build info will be written to.
+
+##### `--message MESSAGE`
+
+If non-empty, uses `MESSAGE` as the commit message / comment, instead of the
+default message (the .dsc file's basename).
 
 ##### `--rebuild-if-unchanged`
 

--- a/obo-core/src/actions.rs
+++ b/obo-core/src/actions.rs
@@ -70,6 +70,8 @@ pub struct DputAction {
     pub build_info_out: Utf8PathBuf,
     #[clap(long, flag_supporting_explicit_value())]
     pub rebuild_if_unchanged: bool,
+    #[clap(long, default_value = "")]
+    pub message: String,
 }
 
 #[derive(Parser, Debug)]
@@ -236,7 +238,12 @@ impl Actions {
         .await?;
         debug!(?initial_build_meta);
 
-        let result = uploader.upload_package(artifacts).await?;
+        let message = if !args.message.is_empty() {
+            Some(args.message.as_str())
+        } else {
+            None
+        };
+        let result = uploader.upload_package(artifacts, message).await?;
 
         // If we couldn't get the metadata before because the package didn't
         // exist yet, get it now but without history, so we leave the previous

--- a/obo-core/src/upload.rs
+++ b/obo-core/src/upload.rs
@@ -248,7 +248,11 @@ impl ObsDscUploader {
     }
 
     #[instrument(skip(artifacts))]
-    pub async fn upload_package(&self, artifacts: &impl ArtifactDirectory) -> Result<UploadResult> {
+    pub async fn upload_package(
+        &self,
+        artifacts: &impl ArtifactDirectory,
+        commit_message: Option<&str>,
+    ) -> Result<UploadResult> {
         let dsc_parent = self
             .dsc_path
             .parent()
@@ -257,6 +261,8 @@ impl ObsDscUploader {
             .dsc_path
             .file_name()
             .ok_or_else(|| eyre!("Invalid dsc path: {}", self.dsc_path))?;
+
+        let commit_message = commit_message.unwrap_or(dsc_filename);
 
         outputln!(
             "Uploading {} to {}/{}...",
@@ -285,7 +291,7 @@ impl ObsDscUploader {
 
         let (rev, unchanged) = if files_to_commit != present_files {
             (
-                self.commit(dsc_filename, dsc_parent, files_to_commit, artifacts)
+                self.commit(commit_message, dsc_parent, files_to_commit, artifacts)
                     .await?,
                 false,
             )
@@ -643,7 +649,7 @@ d29ybGQgaGVsbG8K
             )
             .await
         );
-        let result = assert_ok!(uploader.upload_package(&artifacts).await);
+        let result = assert_ok!(uploader.upload_package(&artifacts, None).await);
         assert_eq!(result.rev, "1");
         assert!(!result.unchanged);
 
@@ -696,7 +702,7 @@ d29ybGQgaGVsbG8K
             )
             .await
         );
-        let result = assert_ok!(uploader.upload_package(&artifacts).await);
+        let result = assert_ok!(uploader.upload_package(&artifacts, Some("extra")).await);
         assert_eq!(result.rev, "3");
         assert!(!result.unchanged);
 
@@ -714,6 +720,10 @@ d29ybGQgaGVsbG8K
 
         assert_eq!(dir.srcmd5, result.build_srcmd5);
 
+        let revisions = assert_ok!(package_1.revisions().await);
+        let revision = assert_some!(revisions.revisions.last());
+        assert_eq!(revision.comment.as_deref(), Some("extra"));
+
         // Change the contents of one of the files.
         artifacts
             .write(format!("subdir/{test1_file}"), test1_contents_b)
@@ -730,7 +740,7 @@ d29ybGQgaGVsbG8K
             )
             .await
         );
-        let result = assert_ok!(uploader.upload_package(&artifacts).await);
+        let result = assert_ok!(uploader.upload_package(&artifacts, None).await);
         assert_eq!(result.rev, "4");
         assert!(!result.unchanged);
 
@@ -760,7 +770,7 @@ d29ybGQgaGVsbG8K
             )
             .await
         );
-        let result = assert_ok!(uploader.upload_package(&artifacts).await);
+        let result = assert_ok!(uploader.upload_package(&artifacts, None).await);
         assert_eq!(result.rev, "5");
         assert!(!result.unchanged);
 
@@ -776,7 +786,7 @@ d29ybGQgaGVsbG8K
 
         // Re-upload with no changes and ensure the old commit is returned.
 
-        let result = assert_ok!(uploader.upload_package(&artifacts).await);
+        let result = assert_ok!(uploader.upload_package(&artifacts, None).await);
         assert_eq!(result.rev, "5");
         assert!(result.unchanged);
 
@@ -796,7 +806,7 @@ d29ybGQgaGVsbG8K
             .await
         );
         assert_eq!(uploader.project(), branched_project);
-        let result = assert_ok!(uploader.upload_package(&artifacts).await);
+        let result = assert_ok!(uploader.upload_package(&artifacts, None).await);
         // TODO: check the revision, once the mock APIs have branches
         // incorporate the origin's history
         assert!(!result.unchanged);

--- a/obo-tests/src/lib.rs
+++ b/obo-tests/src/lib.rs
@@ -113,6 +113,8 @@ pub async fn test_dput<C: TestContext>(
     let dsc1_bad_contents =
         dsc1_contents.replace(test1_file, &(test1_file.to_owned() + ".missing"));
 
+    let commit_message = "my commit";
+
     context.obs().mock.add_project(TEST_PROJECT.to_owned());
 
     context.obs().mock.add_or_update_repository(
@@ -163,9 +165,15 @@ pub async fn test_dput<C: TestContext>(
     let mut dput_command = format!("dput {TEST_PROJECT} {dsc1_file}");
     let mut created_project = TEST_PROJECT.to_owned();
 
-    if test == DputTest::Branch {
-        created_project += ":branched";
-        dput_command += &format!(" --branch-to {created_project}");
+    match test {
+        DputTest::Branch => {
+            created_project += ":branched";
+            dput_command += &format!(" --branch-to {created_project}");
+        }
+        DputTest::Basic => {
+            dput_command += &format!(" --message '{commit_message}'");
+        }
+        _ => {}
     }
 
     let dput = context
@@ -340,15 +348,12 @@ pub async fn test_dput<C: TestContext>(
         assert_none!(arch_2.prev_endtime_for_commit);
     }
 
-    let mut dir = assert_ok!(
-        context
-            .obs()
-            .client
-            .project(created_project.clone())
-            .package(TEST_PACKAGE_1.to_owned())
-            .list(None)
-            .await
-    );
+    let package = context
+        .obs()
+        .client
+        .project(created_project.clone())
+        .package(TEST_PACKAGE_1.to_owned());
+    let mut dir = assert_ok!(package.list(None).await);
 
     assert_eq!(dir.entries.len(), 3);
     dir.entries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -359,6 +364,14 @@ pub async fn test_dput<C: TestContext>(
     assert_eq!(dir.entries[2].name, dsc1_file);
     assert_eq!(dir.entries[2].size, dsc1_contents.len() as u64);
     assert_eq!(dir.entries[2].md5, dsc1_md5);
+
+    let revisions = assert_ok!(package.revisions().await);
+    let revision = assert_some!(revisions.revisions.last());
+    if test == DputTest::Basic {
+        assert_eq!(revision.comment.as_deref(), Some(commit_message));
+    } else {
+        assert_eq!(revision.comment.as_deref(), Some(dsc1_file));
+    }
 
     (dput.artifacts(), build_info)
 }


### PR DESCRIPTION
If non-empty, it replaces the default (the .dsc filename).

Fixes #107.