### PR TITLE
Add support to exclude architectures and repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ dput PROJECT DSC_FILE
   [--message MESSAGE]
   [--rebuild-if-unchanged]
   [--exclude-arch EXCLUDED_ARCH]
+  [--exclude-repo EXCLUDED_REPO]
 ```
 
 This will upload the given .dsc file, as well as any files referenced by it, to

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ dput PROJECT DSC_FILE
   [--build-info-out BUILD_INFO_FILE=build-info.json]
   [--message MESSAGE]
   [--rebuild-if-unchanged]
+  [--exclude-arch EXCLUDED_ARCH]
 ```
 
 This will upload the given .dsc file, as well as any files referenced by it, to

--- a/obo-core/src/actions.rs
+++ b/obo-core/src/actions.rs
@@ -72,6 +72,8 @@ pub struct DputAction {
     pub rebuild_if_unchanged: bool,
     #[clap(long, default_value = "")]
     pub message: String,
+    #[clap(long)]
+    pub exclude_arch: Vec<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -233,6 +235,7 @@ impl Actions {
                 // Getting disabled repos has to happen *after* the upload,
                 // since the new version can change the supported architectures.
                 disabled_repos: DisabledRepos::Keep,
+                exclude_arch: args.exclude_arch.clone(),
             },
         )
         .await?;
@@ -264,6 +267,7 @@ impl Actions {
                     disabled_repos: DisabledRepos::Skip {
                         wait_options: Default::default(),
                     },
+                    exclude_arch: args.exclude_arch,
                 },
             )
             .await?

--- a/obo-core/src/actions.rs
+++ b/obo-core/src/actions.rs
@@ -74,6 +74,8 @@ pub struct DputAction {
     pub message: String,
     #[clap(long)]
     pub exclude_arch: Vec<String>,
+    #[clap(long)]
+    pub exclude_repo: Vec<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -236,6 +238,7 @@ impl Actions {
                 // since the new version can change the supported architectures.
                 disabled_repos: DisabledRepos::Keep,
                 exclude_arch: args.exclude_arch.clone(),
+                exclude_repo: args.exclude_repo.clone(),
             },
         )
         .await?;
@@ -268,6 +271,7 @@ impl Actions {
                         wait_options: Default::default(),
                     },
                     exclude_arch: args.exclude_arch,
+                    exclude_repo: args.exclude_repo,
                 },
             )
             .await?

--- a/obo-core/src/build_meta.rs
+++ b/obo-core/src/build_meta.rs
@@ -57,6 +57,7 @@ pub enum DisabledRepos {
 pub struct BuildMetaOptions {
     pub history_retrieval: BuildHistoryRetrieval,
     pub disabled_repos: DisabledRepos,
+    pub exclude_arch: Vec<String>,
 }
 
 #[instrument(skip(client))]
@@ -157,6 +158,11 @@ impl BuildMeta {
 
         for repo_meta in project_meta.repositories {
             for arch in repo_meta.arches {
+                if options.exclude_arch.contains(&arch) {
+                    debug!(repo = %repo_meta.name, %arch, "Excluded by options");
+                    continue;
+                }
+
                 if let DisabledRepos::Skip { wait_options } = &options.disabled_repos {
                     let status = get_status_when_ready(
                         &client,
@@ -343,6 +349,7 @@ mod tests {
                     disabled_repos: DisabledRepos::Skip {
                         wait_options: Default::default()
                     },
+                    exclude_arch: vec![],
                 }
             )
             .await
@@ -365,10 +372,29 @@ mod tests {
                 TEST_PROJECT.to_owned(),
                 TEST_PACKAGE_1.to_owned(),
                 &BuildMetaOptions {
+                    history_retrieval: BuildHistoryRetrieval::Full,
+                    disabled_repos: DisabledRepos::Skip {
+                        wait_options: Default::default()
+                    },
+                    exclude_arch: vec![TEST_ARCH_1.to_string()],
+                }
+            )
+            .await
+        );
+        assert_eq!(meta.repos.len(), 1);
+        assert!(meta.repos.contains_key(&repo_arch_2));
+
+        let meta = assert_ok!(
+            BuildMeta::get(
+                client.clone(),
+                TEST_PROJECT.to_owned(),
+                TEST_PACKAGE_1.to_owned(),
+                &BuildMetaOptions {
                     history_retrieval: BuildHistoryRetrieval::None,
                     disabled_repos: DisabledRepos::Skip {
                         wait_options: Default::default()
                     },
+                    exclude_arch: vec![],
                 }
             )
             .await
@@ -416,6 +442,7 @@ mod tests {
                     disabled_repos: DisabledRepos::Skip {
                         wait_options: Default::default()
                     },
+                    exclude_arch: vec![],
                 }
             )
             .await
@@ -450,6 +477,7 @@ mod tests {
                     disabled_repos: DisabledRepos::Skip {
                         wait_options: Default::default()
                     },
+                    exclude_arch: vec![],
                 }
             )
             .await
@@ -485,6 +513,7 @@ mod tests {
                     disabled_repos: DisabledRepos::Skip {
                         wait_options: Default::default()
                     },
+                    exclude_arch: vec![],
                 }
             )
             .await
@@ -499,6 +528,7 @@ mod tests {
                 &BuildMetaOptions {
                     history_retrieval: BuildHistoryRetrieval::Full,
                     disabled_repos: DisabledRepos::Keep,
+                    exclude_arch: vec![],
                 }
             )
             .await
@@ -556,7 +586,8 @@ mod tests {
                     history_retrieval: BuildHistoryRetrieval::Full,
                     disabled_repos: DisabledRepos::Skip {
                         wait_options: Default::default()
-                    }
+                    },
+                    exclude_arch: vec![],
                 }
             )
             .await
@@ -611,6 +642,7 @@ mod tests {
                     } else {
                         DisabledRepos::Keep
                     },
+                    exclude_arch: vec![],
                 }
             )
             .await

--- a/obo-core/src/build_meta.rs
+++ b/obo-core/src/build_meta.rs
@@ -58,6 +58,7 @@ pub struct BuildMetaOptions {
     pub history_retrieval: BuildHistoryRetrieval,
     pub disabled_repos: DisabledRepos,
     pub exclude_arch: Vec<String>,
+    pub exclude_repo: Vec<String>,
 }
 
 #[instrument(skip(client))]
@@ -157,6 +158,11 @@ impl BuildMeta {
         let mut repos = HashMap::new();
 
         for repo_meta in project_meta.repositories {
+            if options.exclude_repo.contains(&repo_meta.name) {
+                debug!(repo = %repo_meta.name, "Excluded by options");
+                continue;
+            }
+
             for arch in repo_meta.arches {
                 if options.exclude_arch.contains(&arch) {
                     debug!(repo = %repo_meta.name, %arch, "Excluded by options");
@@ -350,6 +356,7 @@ mod tests {
                         wait_options: Default::default()
                     },
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -377,6 +384,7 @@ mod tests {
                         wait_options: Default::default()
                     },
                     exclude_arch: vec![TEST_ARCH_1.to_string()],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -395,6 +403,7 @@ mod tests {
                         wait_options: Default::default()
                     },
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -443,6 +452,7 @@ mod tests {
                         wait_options: Default::default()
                     },
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -478,6 +488,7 @@ mod tests {
                         wait_options: Default::default()
                     },
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -514,6 +525,7 @@ mod tests {
                         wait_options: Default::default()
                     },
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -529,6 +541,7 @@ mod tests {
                     history_retrieval: BuildHistoryRetrieval::Full,
                     disabled_repos: DisabledRepos::Keep,
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -537,6 +550,68 @@ mod tests {
 
         assert_ok!(meta.remove_disabled_repos(&Default::default()).await);
         assert_eq!(meta.repos.len(), 0);
+
+        mock.add_or_update_repository(
+            TEST_PROJECT,
+            TEST_REPO.to_owned(),
+            TEST_ARCH_1.to_owned(),
+            MockRepositoryCode::Finished,
+        );
+
+        mock.add_or_update_repository(
+            TEST_PROJECT,
+            TEST_REPO.to_owned(),
+            TEST_ARCH_2.to_owned(),
+            MockRepositoryCode::Finished,
+        );
+
+        mock.add_or_update_repository(
+            TEST_PROJECT,
+            TEST_REPO_EXTRA.to_owned(),
+            TEST_ARCH_1.to_owned(),
+            MockRepositoryCode::Finished,
+        );
+
+        mock.add_or_update_repository(
+            TEST_PROJECT,
+            TEST_REPO_EXTRA.to_owned(),
+            TEST_ARCH_2.to_owned(),
+            MockRepositoryCode::Finished,
+        );
+
+        let meta = assert_ok!(
+            BuildMeta::get(
+                client.clone(),
+                TEST_PROJECT.to_owned(),
+                TEST_PACKAGE_1.to_owned(),
+                &BuildMetaOptions {
+                    history_retrieval: BuildHistoryRetrieval::Full,
+                    disabled_repos: DisabledRepos::Keep,
+                    exclude_arch: vec![],
+                    exclude_repo: vec![],
+                }
+            )
+            .await
+        );
+        assert_eq!(meta.repos.len(), 4);
+
+        let meta = assert_ok!(
+            BuildMeta::get(
+                client.clone(),
+                TEST_PROJECT.to_owned(),
+                TEST_PACKAGE_1.to_owned(),
+                &BuildMetaOptions {
+                    history_retrieval: BuildHistoryRetrieval::Full,
+                    disabled_repos: DisabledRepos::Keep,
+                    exclude_arch: vec![],
+                    exclude_repo: vec![TEST_REPO_EXTRA.to_owned()],
+                }
+            )
+            .await
+        );
+        assert_eq!(meta.repos.len(), 2);
+        assert!(meta.repos.contains_key(&repo_arch_1));
+        assert!(meta.repos.contains_key(&repo_arch_2));
     }
 
     #[rstest]
@@ -588,6 +663,7 @@ mod tests {
                         wait_options: Default::default()
                     },
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await
@@ -643,6 +719,7 @@ mod tests {
                         DisabledRepos::Keep
                     },
                     exclude_arch: vec![],
+                    exclude_repo: vec![],
                 }
             )
             .await

--- a/obo-test-support/src/lib.rs
+++ b/obo-test-support/src/lib.rs
@@ -8,6 +8,7 @@ pub const TEST_PROJECT: &str = "foo";
 pub const TEST_PACKAGE_1: &str = "bar";
 pub const TEST_PACKAGE_2: &str = "baz";
 pub const TEST_REPO: &str = "repo";
+pub const TEST_REPO_EXTRA: &str = "repo_extra";
 pub const TEST_ARCH_1: &str = "aarch64";
 pub const TEST_ARCH_2: &str = "x86_64";
 


### PR DESCRIPTION
In some use cases it is useful to exclude architectures and repositories as those builds should not block a pipeline. To allow that add a set of new arguments to dput.